### PR TITLE
Some fixes to holding and transaction endpoints

### DIFF
--- a/zappa/api/serializers.py
+++ b/zappa/api/serializers.py
@@ -37,9 +37,6 @@ class PortfolioSerializer(serializers.ModelSerializer):
 
       
 class TransactionSerializer(serializers.ModelSerializer):
-    portfolio = PortfolioSerializer(many=False)
-    holding = HoldingSerializer(many=False)
-
     class Meta:
         model = Transaction
         fields = "__all__"

--- a/zappa/api/urls.py
+++ b/zappa/api/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path('buystock/<str:pk>', views.buyStock),
     path('sellstock/<str:pk>', views.sellStock),
     path('holdings/', views.getHoldings),
-    path('holding/<str:pk>', views.getHolding),
+    path('holdings/<str:pk>', views.getHolding),
     path('transactions/', views.getTransactions),
     path('transactions/<str:pk>', views.getTransaction),
 ]

--- a/zappa/api/views.py
+++ b/zappa/api/views.py
@@ -14,16 +14,16 @@ def getRoutes(request):
 
     routes = [
         {'GET': '/api/portfolios'},
-        {'GET': '/api/portfolio/id'},
+        {'GET': '/api/portfolios/id'},
         {'POST': '/api/newportfolio'},
         {'POST': '/api/buystock/id'},
         {'POST': '/api/sellstock/id'},
         {'GET': '/api/holdings'},
-        {'GET': '/api/holding/id'},
+        {'GET': '/api/holdings/id'},
         {'GET': '/api/transactions'},
-        {'GET': '/api/transaction/id'},
+        {'GET': '/api/transactions/id'},
         {'GET': '/api/games'},
-        {'GET': '/api/game/id'},
+        {'GET': '/api/games/id'},
     ]
 
     return Response(routes)
@@ -80,7 +80,7 @@ def getHoldings(request):
 
 @api_view(['GET'])
 def getHolding(request, pk):
-    holding = Holding.objects.get()
+    holding = Holding.objects.get(id=pk)
     serializer = HoldingSerializer(holding, many=False)
     return Response(serializer.data)
 
@@ -94,7 +94,7 @@ def getTransactions(request):
 
 @api_view(["GET"])
 def getTransaction(request, pk):
-    transaction = Transaction.objects.get()
+    transaction = Transaction.objects.get(id=pk)
     serializer = TransactionSerializer(transaction, many=False)
     return Response(serializer.data)
 


### PR DESCRIPTION
Some fixes so that some of the less-used endpoints will work as intended.
Also removed Portfolio and Holding serializers from Transaction record so that it will be readable.